### PR TITLE
fix: cancel share retrieval if array is started separately

### DIFF
--- a/autounlock/get.go
+++ b/autounlock/get.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -145,6 +146,10 @@ func GetShares(
 	}
 
 	for {
+		if (!VerifyArrayStatus("Stopped")) && !test {
+			return nil, errors.New("array is no longer stopped, aborting share retrieval")
+		}
+
 		for pathNum, path := range paths {
 			// Skip paths we've already tried
 			if triedPaths[path] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and abort retrieval operations when array state changes unexpectedly, preventing potential errors during processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->