### PR TITLE
fix: add gitignore file to prevent config/encrypted keyfile from going to flash backup

### DIFF
--- a/plugin/plugin.j2
+++ b/plugin/plugin.j2
@@ -61,6 +61,16 @@ echo ""
 </INLINE>
 </FILE>
 
+<FILE Name="/boot/config/plugins/{{ name }}/.gitignore">
+<INLINE>
+<![CDATA[
+unlock.enc
+state.json
+config.txt
+]]>
+</INLINE>
+</FILE>
+
 <!--
 The 'unlock' script. This only runs if /var/local/emhttp/var.ini does not exist yet.
 -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin installation to automatically exclude temporary and state files from version control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->