### PR TITLE
fix: avoid race condition if native auto-start is enabled

### DIFF
--- a/autounlock/secrets/get.go
+++ b/autounlock/secrets/get.go
@@ -275,5 +275,5 @@ func logSharePaths(paths []string) {
 }
 
 func shouldAbort(fs afero.Fs, test bool) bool {
-	return (!unraid.VerifyArrayStatus(fs, "Stopped")) && !test
+	return (unraid.VerifyArrayStatus(fs, "Started")) && !test
 }


### PR DESCRIPTION
Checks for fsState=Stopped will now retry, because if the native auto-start is enabled, fsState will briefly report "Starting" before failing and switching back to "Stopped". This was causing the autounlock to incorrectly stop.

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging with contextual details during unlock, state loading, and decryption operations
  * Enhanced array status verification logic

* **Refactor**
  * Implemented timeout-based monitoring for array status changes instead of immediate checks
  * Generalized status verification mechanism for improved reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->