### PR TITLE
fix: retry start once if emhttpd fails

### DIFF
--- a/autounlock/constants/constants.go
+++ b/autounlock/constants/constants.go
@@ -6,6 +6,7 @@ const (
 	ArrayRetryDelay    = 15 * time.Second
 	ArrayStatusTimeout = 120 * time.Second
 	ArrayTimeout       = 15 * time.Minute
+	StartRetryDelay    = 30 * time.Second
 
 	EncryptionKeyBytes = 32
 	EncryptionFileMode = 0o600

--- a/autounlock/unlock.go
+++ b/autounlock/unlock.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dkaser/unraid-auto-unlock/autounlock/constants"
 	"github.com/dkaser/unraid-auto-unlock/autounlock/state"
@@ -63,7 +64,14 @@ func (a *AutoUnlock) Unlock() error {
 
 	err = a.unraid.StartArray()
 	if err != nil {
-		return fmt.Errorf("failed to start array: %w", err)
+		// Wait 30 seconds and try again once
+		log.Warn().Err(err).Msg("Failed to start array, retrying in 30 seconds")
+		time.Sleep(constants.StartRetryDelay)
+
+		err = a.unraid.StartArray()
+		if err != nil {
+			return fmt.Errorf("failed to start array: %w", err)
+		}
 	}
 
 	err = a.unraid.WaitForArrayStatus("Started", constants.ArrayTimeout)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced unlock reliability by implementing an automatic retry mechanism. When an unlock operation fails initially, the system will now retry once after a 30-second delay before reporting the failure, reducing transient failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->