### PR TITLE
fix: check if array started before retrying

### DIFF
--- a/autounlock/unlock.go
+++ b/autounlock/unlock.go
@@ -64,9 +64,14 @@ func (a *AutoUnlock) Unlock() error {
 
 	err = a.unraid.StartArray()
 	if err != nil {
-		// Wait 30 seconds and try again once
 		log.Warn().Err(err).Msg("Failed to start array, retrying in 30 seconds")
 		time.Sleep(constants.StartRetryDelay)
+
+		// Check if array is already started before retrying
+		started := a.unraid.VerifyArrayStatus("Started")
+		if started {
+			return nil
+		}
 
 		err = a.unraid.StartArray()
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced array startup handling to reduce unnecessary retries. When an initial startup attempt fails, the system now verifies if the array is already running before retrying, improving responsiveness in certain scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->