### PR TITLE
refactor: move fetch methods into packages

### DIFF
--- a/autounlock/.golangci.yml
+++ b/autounlock/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - exhaustruct
     - forbidigo
     - gochecknoglobals
+    - gochecknoinits # Required for fetcher registry
     - noctx
     - lll
     - testpackage
@@ -32,7 +33,6 @@ linters:
 
 formatters:
   enable:
-    - gci
     - gofmt
     - gofumpt
     - goimports

--- a/autounlock/secrets/dns/dns.go
+++ b/autounlock/secrets/dns/dns.go
@@ -5,13 +5,39 @@ import (
 	"fmt"
 	"net"
 	"strings"
+
+	"github.com/dkaser/unraid-auto-unlock/autounlock/secrets/registry"
 )
 
-// Fetch retrieves secret data from DNS TXT records.
-// The path should be a domain name (without the "dns:" prefix).
-func Fetch(ctx context.Context, domain string) (string, error) {
-	// Use a custom resolver that respects context
-	resolver := &net.Resolver{}
+const (
+	// PriorityDNS is the priority for DNS fetcher (checked early, explicit prefix).
+	PriorityDNS = 10
+)
+
+func init() {
+	registry.Register(&Fetcher{})
+}
+
+type Fetcher struct {
+	Resolver *net.Resolver
+}
+
+func (f *Fetcher) Match(path string) bool {
+	return strings.HasPrefix(path, "dns:")
+}
+
+func (f *Fetcher) Priority() int {
+	return PriorityDNS
+}
+
+func (f *Fetcher) Fetch(ctx context.Context, domain string) (string, error) {
+	// Use the configured resolver or create a default one
+	resolver := f.Resolver
+	if resolver == nil {
+		resolver = &net.Resolver{}
+	}
+
+	domain = strings.TrimPrefix(domain, "dns:")
 
 	txts, err := resolver.LookupTXT(ctx, domain)
 	if err != nil {

--- a/autounlock/secrets/dns/dns_test.go
+++ b/autounlock/secrets/dns/dns_test.go
@@ -14,10 +14,11 @@ func TestFetch_ValidDomain(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
 	// Using a commonly available test domain - this is just to verify the mechanism works
 	// In production, users would use their own domains
-	_, err := Fetch(ctx, "google.com")
+	_, err := fetcher.Fetch(ctx, "dns:google.com")
 	if err != nil {
 		t.Logf("DNS lookup for google.com failed (this is OK if network is unavailable): %v", err)
 	}
@@ -31,9 +32,10 @@ func TestFetch_InvalidDomain(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
 	// Use a domain that should not exist
-	_, err := Fetch(ctx, "this-domain-definitely-does-not-exist-12345.invalid")
+	_, err := fetcher.Fetch(ctx, "dns:this-domain-definitely-does-not-exist-12345.invalid")
 	if err == nil {
 		t.Error("Expected error for non-existent domain, got none")
 	}
@@ -46,8 +48,9 @@ func TestFetch_InvalidDomain(t *testing.T) {
 // TestFetch_EmptyDomain tests DNS TXT record lookup with an empty domain.
 func TestFetch_EmptyDomain(t *testing.T) {
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	_, err := Fetch(ctx, "")
+	_, err := fetcher.Fetch(ctx, "dns:")
 	if err == nil {
 		t.Error("Expected error for empty domain, got none")
 	}
@@ -63,7 +66,9 @@ func TestFetch_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := Fetch(ctx, "google.com")
+	fetcher := &Fetcher{}
+
+	_, err := fetcher.Fetch(ctx, "dns:google.com")
 	if err == nil {
 		t.Error("Expected error due to context cancellation, got none")
 	}

--- a/autounlock/secrets/http/http_test.go
+++ b/autounlock/secrets/http/http_test.go
@@ -38,8 +38,9 @@ func TestFetch_Success(t *testing.T) {
 			defer server.Close()
 
 			ctx := context.Background()
+			fetcher := &Fetcher{}
 
-			got, err := Fetch(ctx, server.URL)
+			got, err := fetcher.Fetch(ctx, server.URL)
 			if err != nil {
 				t.Fatalf("Fetch failed: %v", err)
 			}
@@ -80,8 +81,9 @@ func TestFetch_BasicAuth(t *testing.T) {
 		String()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, urlWithAuth)
+	got, err := fetcher.Fetch(ctx, urlWithAuth)
 	if err != nil {
 		t.Fatalf("Fetch with basic auth failed: %v", err)
 	}
@@ -102,8 +104,9 @@ func TestFetch_InsecureTLS(t *testing.T) {
 
 	// Standard HTTPS request should fail with self-signed cert
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	_, err := Fetch(ctx, server.URL)
+	_, err := fetcher.Fetch(ctx, server.URL)
 	if err == nil {
 		t.Error("Expected error with self-signed certificate, got none")
 	}
@@ -111,7 +114,7 @@ func TestFetch_InsecureTLS(t *testing.T) {
 	// Request with https+insecure:// should succeed
 	insecureURL := "https+insecure://" + server.Listener.Addr().String()
 
-	got, err := Fetch(ctx, insecureURL)
+	got, err := fetcher.Fetch(ctx, insecureURL)
 	if err != nil {
 		t.Fatalf("Fetch with insecure flag failed: %v", err)
 	}
@@ -143,8 +146,9 @@ func TestFetch_HTTPStatusErrors(t *testing.T) {
 			defer server.Close()
 
 			ctx := context.Background()
+			fetcher := &Fetcher{}
 
-			_, err := Fetch(ctx, server.URL)
+			_, err := fetcher.Fetch(ctx, server.URL)
 			if err == nil {
 				t.Errorf("Expected error for status code %d, got none", tc.statusCode)
 			}
@@ -167,8 +171,9 @@ func TestFetch_InvalidURLs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
+			fetcher := &Fetcher{}
 
-			_, err := Fetch(ctx, tc.url)
+			_, err := fetcher.Fetch(ctx, tc.url)
 			if err == nil {
 				t.Errorf("Expected error for URL %q, got none", tc.url)
 			}
@@ -193,8 +198,9 @@ func TestFetch_SubdirectoryPath(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, server.URL+"/share/subdir/file.txt")
+	got, err := fetcher.Fetch(ctx, server.URL+"/share/subdir/file.txt")
 	if err != nil {
 		t.Fatalf("Fetch with subdirectory path failed: %v", err)
 	}
@@ -228,8 +234,9 @@ func TestFetch_CombinedFeatures(t *testing.T) {
 		String()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, urlWithAuth)
+	got, err := fetcher.Fetch(ctx, urlWithAuth)
 	if err != nil {
 		t.Fatalf("Fetch with combined features failed: %v", err)
 	}
@@ -272,8 +279,9 @@ func TestFetch_URLEncodedCredentials(t *testing.T) {
 		String()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, urlWithAuth)
+	got, err := fetcher.Fetch(ctx, urlWithAuth)
 	if err != nil {
 		t.Fatalf("Fetch with encoded credentials failed: %v", err)
 	}
@@ -294,8 +302,9 @@ func TestFetch_ResponseTooLarge(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	_, err := Fetch(ctx, server.URL)
+	_, err := fetcher.Fetch(ctx, server.URL)
 	if err == nil {
 		t.Error("Expected error for response body too large, got none")
 	}
@@ -316,8 +325,9 @@ func TestFetch_ResponseAtLimit(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, server.URL)
+	got, err := fetcher.Fetch(ctx, server.URL)
 	if err != nil {
 		t.Fatalf("Fetch failed for response at limit: %v", err)
 	}

--- a/autounlock/secrets/rclone/rclone_test.go
+++ b/autounlock/secrets/rclone/rclone_test.go
@@ -21,8 +21,9 @@ func TestFetch_LocalFile(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, testFile)
+	got, err := fetcher.Fetch(ctx, testFile)
 	if err != nil {
 		t.Fatalf("Fetch failed: %v", err)
 	}
@@ -44,8 +45,9 @@ func TestFetch_LocalFileWithWhitespace(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, testFile)
+	got, err := fetcher.Fetch(ctx, testFile)
 	if err != nil {
 		t.Fatalf("Fetch failed: %v", err)
 	}
@@ -72,8 +74,9 @@ func TestFetch_RelativePath(t *testing.T) {
 	t.Chdir(tmpDir)
 
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	got, err := Fetch(ctx, "relative.txt")
+	got, err := fetcher.Fetch(ctx, "relative.txt")
 	if err != nil {
 		t.Fatalf("Fetch failed: %v", err)
 	}
@@ -86,8 +89,9 @@ func TestFetch_RelativePath(t *testing.T) {
 // TestFetch_NonExistentFile tests fetching a non-existent file.
 func TestFetch_NonExistentFile(t *testing.T) {
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
-	_, err := Fetch(ctx, "/nonexistent/path/to/file.txt")
+	_, err := fetcher.Fetch(ctx, "/nonexistent/path/to/file.txt")
 	if err == nil {
 		t.Error("Expected error for non-existent file, got none")
 	}
@@ -96,9 +100,10 @@ func TestFetch_NonExistentFile(t *testing.T) {
 // TestFetch_InvalidBackendPath tests fetching with an invalid backend path.
 func TestFetch_InvalidBackendPath(t *testing.T) {
 	ctx := context.Background()
+	fetcher := &Fetcher{}
 
 	// Backend path without a slash should fail
-	_, err := Fetch(ctx, ":s3:invalid")
+	_, err := fetcher.Fetch(ctx, ":s3:invalid")
 	if err == nil {
 		t.Error("Expected error for invalid backend path, got none")
 	}

--- a/autounlock/secrets/registry/registry.go
+++ b/autounlock/secrets/registry/registry.go
@@ -1,0 +1,51 @@
+package registry
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// Fetcher is an interface for fetching secret data from various sources.
+type Fetcher interface {
+	// Fetch retrieves the secret data from the given path.
+	Fetch(ctx context.Context, path string) (string, error)
+	// Match checks if this fetcher can handle the given path.
+	// Returns true if matched, false otherwise.
+	Match(path string) bool
+	// Priority returns the priority of this fetcher (lower number = higher priority).
+	// Multiple fetchers with the same priority can run in any order.
+	Priority() int
+}
+
+var (
+	registryMu sync.RWMutex
+	fetchers   []Fetcher
+)
+
+// Register adds a new fetcher to the registry.
+// Fetchers are automatically sorted by priority (lower number = higher priority).
+// Each package should call this in its init() function to self-register.
+func Register(fetcher Fetcher) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	fetchers = append(fetchers, fetcher)
+
+	// Sort fetchers by priority (lower number = higher priority)
+	sort.Slice(fetchers, func(i, j int) bool {
+		return fetchers[i].Priority() < fetchers[j].Priority()
+	})
+}
+
+// GetFetchers returns a copy of the registered fetchers in priority order.
+func GetFetchers() []Fetcher {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	// Return a copy to prevent external modification
+	result := make([]Fetcher, len(fetchers))
+	copy(result, fetchers)
+
+	return result
+}

--- a/autounlock/secrets/registry/registry_test.go
+++ b/autounlock/secrets/registry/registry_test.go
@@ -1,0 +1,381 @@
+package registry
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// mockFetcher is a test implementation of the Fetcher interface.
+type mockFetcher struct {
+	name     string
+	priority int
+	matches  bool
+}
+
+func (m *mockFetcher) Fetch(_ context.Context, _ string) (string, error) {
+	return m.name, nil
+}
+
+func (m *mockFetcher) Match(_ string) bool {
+	return m.matches
+}
+
+func (m *mockFetcher) Priority() int {
+	return m.priority
+}
+
+// TestRegister_SingleFetcher tests registering a single fetcher.
+func TestRegister_SingleFetcher(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	mock := &mockFetcher{name: "test", priority: 10, matches: true}
+	Register(mock)
+
+	got := GetFetchers()
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 fetcher, got %d", len(got))
+	}
+
+	if got[0] != mock {
+		t.Error("Fetcher not registered correctly")
+	}
+}
+
+// TestRegister_MultipleFetchers tests registering multiple fetchers.
+func TestRegister_MultipleFetchers(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	mock1 := &mockFetcher{name: "first", priority: 10, matches: true}
+	mock2 := &mockFetcher{name: "second", priority: 20, matches: true}
+	mock3 := &mockFetcher{name: "third", priority: 5, matches: true}
+
+	Register(mock1)
+	Register(mock2)
+	Register(mock3)
+
+	got := GetFetchers()
+	if len(got) != 3 {
+		t.Fatalf("Expected 3 fetchers, got %d", len(got))
+	}
+}
+
+// TestRegister_SortsByPriority tests that fetchers are sorted by priority.
+func TestRegister_SortsByPriority(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	// Register in random order
+	mock1 := &mockFetcher{name: "low-priority", priority: 100, matches: true}
+	mock2 := &mockFetcher{name: "high-priority", priority: 10, matches: true}
+	mock3 := &mockFetcher{name: "medium-priority", priority: 50, matches: true}
+
+	Register(mock1)
+	Register(mock2)
+	Register(mock3)
+
+	got := GetFetchers()
+	if len(got) != 3 {
+		t.Fatalf("Expected 3 fetchers, got %d", len(got))
+	}
+
+	// Should be sorted by priority (lower number first)
+	if got[0].Priority() != 10 {
+		t.Errorf("First fetcher priority = %d, want 10", got[0].Priority())
+	}
+
+	if got[1].Priority() != 50 {
+		t.Errorf("Second fetcher priority = %d, want 50", got[1].Priority())
+	}
+
+	if got[2].Priority() != 100 {
+		t.Errorf("Third fetcher priority = %d, want 100", got[2].Priority())
+	}
+}
+
+// TestRegister_SamePriority tests multiple fetchers with the same priority.
+func TestRegister_SamePriority(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	mock1 := &mockFetcher{name: "first", priority: 10, matches: true}
+	mock2 := &mockFetcher{name: "second", priority: 10, matches: true}
+	mock3 := &mockFetcher{name: "third", priority: 5, matches: true}
+
+	Register(mock1)
+	Register(mock2)
+	Register(mock3)
+
+	got := GetFetchers()
+	if len(got) != 3 {
+		t.Fatalf("Expected 3 fetchers, got %d", len(got))
+	}
+
+	// First should have priority 5
+	if got[0].Priority() != 5 {
+		t.Errorf("First fetcher priority = %d, want 5", got[0].Priority())
+	}
+
+	// Second and third should both have priority 10 (order doesn't matter between them)
+	if got[1].Priority() != 10 || got[2].Priority() != 10 {
+		t.Error("Expected remaining fetchers to have priority 10")
+	}
+}
+
+// TestGetFetchers_ReturnsACopy tests that GetFetchers returns a copy, not the original slice.
+func TestGetFetchers_ReturnsACopy(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	mock := &mockFetcher{name: "test", priority: 10, matches: true}
+	Register(mock)
+
+	// Get fetchers twice
+	got1 := GetFetchers()
+	got2 := GetFetchers()
+
+	// Should be different slices
+	if &got1[0] == &got2[0] {
+		t.Error("GetFetchers should return a copy, not the same slice")
+	}
+
+	// But contain the same fetchers
+	if got1[0] != got2[0] {
+		t.Error("GetFetchers should contain the same fetcher instances")
+	}
+}
+
+// TestGetFetchers_ModifyingReturnedSlice tests that modifying the returned slice doesn't affect the registry.
+func TestGetFetchers_ModifyingReturnedSlice(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	mock := &mockFetcher{name: "test", priority: 10, matches: true}
+	Register(mock)
+
+	// Get fetchers and try to modify the slice
+	got := GetFetchers()
+	originalLen := len(got)
+
+	// Try to append to the returned slice (should not affect registry)
+	_ = append(got, &mockFetcher{name: "hacker", priority: 1, matches: true})
+
+	// Get fetchers again
+	got2 := GetFetchers()
+
+	if len(got2) != originalLen {
+		t.Errorf(
+			"Registry was modified by external slice modification: got %d, want %d",
+			len(got2),
+			originalLen,
+		)
+	}
+}
+
+// TestRegister_ConcurrentAccess tests thread-safety of Register.
+func TestRegister_ConcurrentAccess(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	const numGoroutines = 10
+
+	const numRegistrations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Concurrently register fetchers
+	for i := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+
+			for j := range numRegistrations {
+				mock := &mockFetcher{
+					name:     "concurrent",
+					priority: id*numRegistrations + j,
+					matches:  true,
+				}
+				Register(mock)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	got := GetFetchers()
+	expected := numGoroutines * numRegistrations
+
+	if len(got) != expected {
+		t.Errorf("Expected %d fetchers after concurrent registration, got %d", expected, len(got))
+	}
+
+	// Verify they're sorted
+	for i := 1; i < len(got); i++ {
+		if got[i].Priority() < got[i-1].Priority() {
+			t.Error("Fetchers not properly sorted after concurrent registration")
+
+			break
+		}
+	}
+}
+
+// TestGetFetchers_ConcurrentAccess tests thread-safety of GetFetchers.
+func TestGetFetchers_ConcurrentAccess(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry and add some fetchers
+	fetchers = nil
+
+	for i := range 10 {
+		Register(&mockFetcher{name: "test", priority: i, matches: true})
+	}
+
+	const numGoroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Concurrently read from registry
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+
+			for range 100 {
+				got := GetFetchers()
+				if len(got) != 10 {
+					t.Errorf("Expected 10 fetchers, got %d", len(got))
+
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestRegister_AndGetFetchers_ConcurrentMixed tests concurrent Register and GetFetchers.
+func TestRegister_AndGetFetchers_ConcurrentMixed(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	const numGoroutines = 20
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Half the goroutines register, half read
+	for i := range numGoroutines {
+		if i%2 == 0 {
+			// Register
+			go func(id int) {
+				defer wg.Done()
+
+				for j := range 50 {
+					Register(&mockFetcher{
+						name:     "mixed",
+						priority: id*50 + j,
+						matches:  true,
+					})
+				}
+			}(i)
+		} else {
+			// Read
+			go func() {
+				defer wg.Done()
+
+				for range 50 {
+					got := GetFetchers()
+					// Just verify we don't panic or get corrupted data
+					if got == nil {
+						t.Error("GetFetchers returned nil")
+
+						return
+					}
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	// Verify final state
+	got := GetFetchers()
+	if len(got) == 0 {
+		t.Error("Expected fetchers to be registered")
+	}
+
+	// Verify they're sorted
+	for i := 1; i < len(got); i++ {
+		if got[i].Priority() < got[i-1].Priority() {
+			t.Error("Fetchers not properly sorted after mixed concurrent access")
+
+			break
+		}
+	}
+}
+
+// TestGetFetchers_EmptyRegistry tests getting fetchers from an empty registry.
+func TestGetFetchers_EmptyRegistry(t *testing.T) {
+	// Save and restore original state
+	originalFetchers := fetchers
+
+	defer func() { fetchers = originalFetchers }()
+
+	// Clear registry
+	fetchers = nil
+
+	got := GetFetchers()
+	if got == nil {
+		t.Error("GetFetchers should not return nil")
+	}
+
+	if len(got) != 0 {
+		t.Errorf("Expected empty slice, got %d fetchers", len(got))
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DNS TXT record lookup for secret resolution using `dns:` prefix
  * Added Rclone-based fetcher for accessing secrets from local and remote file backends
  * Implemented extensible fetcher registry system with priority-based resolution

* **Refactor**
  * Consolidated secret resolution logic into a pluggable registry system

* **Chores**
  * Updated linter configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->