### PR TITLE
fix: make sure keyfile is cleaned up if process is killed

### DIFF
--- a/autounlock/main.go
+++ b/autounlock/main.go
@@ -48,9 +48,11 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {
-		<-sigChan
+		sig := <-sigChan
+		log.Warn().Str("signal", sig.String()).Msg("Received signal, cleaning up")
 		autoUnlock.RemoveKeyfile()
-		os.Exit(1)
+		signal.Reset(sig)
+		syscall.Kill(syscall.Getpid(), sig.(syscall.Signal)) //nolint:errcheck,forcetypeassert
 	}()
 
 	lockFile, err := lockApp()

--- a/autounlock/main.go
+++ b/autounlock/main.go
@@ -20,6 +20,9 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -40,6 +43,15 @@ func main() {
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("Failed to initialize AutoUnlock")
 	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		<-sigChan
+		autoUnlock.RemoveKeyfile()
+		os.Exit(1)
+	}()
 
 	lockFile, err := lockApp()
 	if err != nil {

--- a/autounlock/unlock.go
+++ b/autounlock/unlock.go
@@ -47,6 +47,8 @@ func (a *AutoUnlock) Unlock() error {
 		return fmt.Errorf("failed to read state from file: %w", err)
 	}
 
+	defer a.RemoveKeyfile()
+
 	secret, err := a.retrieveSecret(state)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve secret: %w", err)
@@ -61,8 +63,6 @@ func (a *AutoUnlock) Unlock() error {
 	if err != nil {
 		return fmt.Errorf("failed to decrypt file: %w", err)
 	}
-
-	defer a.RemoveKeyfile()
 
 	log.Info().
 		Str("encryptedfile", a.args.EncryptedFile).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application now properly handles termination signals to ensure graceful shutdown.
  * Keyfile cleanup is guaranteed during shutdown, even if errors occur during the unlock process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->